### PR TITLE
Update routes.js

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -27,8 +27,8 @@ module.exports.routes = {
   },
 
   'GET /download/latest/:platform?': 'AssetController.download',
-  'GET /download/:version/:platform?/:filename?': 'AssetController.download',
   'GET /download/channel/:channel/:platform?': 'AssetController.download',
+  'GET /download/:version/:platform?/:filename?': 'AssetController.download',
 
   'GET /update': 'VersionController.redirect',
   'GET /update/:platform/:version': 'VersionController.general',


### PR DESCRIPTION
The way your routes were ordered, you would never be able to access /download/channel/:channel/:platform