### PR TITLE
Persist uploads when using Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,4 +19,4 @@ nbproject
 .node_history
 Dockerfile
 docker-compose.json
-docker-data
+docker-assets

--- a/.dockerignore
+++ b/.dockerignore
@@ -19,3 +19,4 @@ nbproject
 .node_history
 Dockerfile
 docker-compose.json
+docker-data

--- a/config/docker.js
+++ b/config/docker.js
@@ -38,7 +38,7 @@ module.exports = {
     token_secret: process.env['TOKEN_SECRET'],
   },
   files: {
-    dirname: '/tmp/',
+    dirname: '/assets/',
   },
   session: {
     // Recommended: 63 random alpha-numeric characters

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 version: '2'
 services:
   web:
+    restart: always
+    volumes:
+      - ./docker-data:/tmp
     build: .
     environment:
       APP_USERNAME: username

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   web:
     restart: always
     volumes:
-      - ./docker-data:/tmp
+      - ./docker-assets:/assets
     build: .
     environment:
       APP_USERNAME: username


### PR DESCRIPTION
When using Docker, I saw that after a restart, the database was still here, but the assets I uploaded were lost. This is because the `/tmp` folder in Docker was erased.

I just added an option to persist it (in the folder `./docker-data`).