### PR TITLE
Fix Angular versions to prevent errors

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,9 +2,9 @@
   "name": "electron-release-server",
   "private": true,
   "dependencies": {
-    "angular": "^1.5.9",
+    "angular": "1.5.9",
     "bootstrap-sass-official": "^3.3.7",
-    "angular-animate": "~1.5.9",
+    "angular-animate": "1.5.9",
     "angular-messages": "~1.5.9",
     "angular-route": "~1.5.9",
     "angular-sanitize": "~1.5.9",


### PR DESCRIPTION
I was having issues trying the application because the `bower.json` had permissive version descriptions, so Angular was being installed with version `1.6.x`, leading to the problem described in: https://github.com/ArekSredzki/electron-release-server#maintenance

This PR just "fixes" the versions in `bower.json` to the specific releases that are documented as working.