### PR TITLE
Add STORAGE_PATH for specifying custom storage path

### DIFF
--- a/config/docker.js
+++ b/config/docker.js
@@ -38,7 +38,7 @@ module.exports = {
     token_secret: process.env['TOKEN_SECRET'],
   },
   files: {
-    dirname: '/tmp/',
+    dirname: process.env['STORAGE_PATH'] || '/tmp/',
   },
   session: {
     // Recommended: 63 random alpha-numeric characters

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -27,6 +27,7 @@ To run the single container provide the next environment variables:
 - `DB_USERNAME`, `DB_PASSWORD` – credentials to access postgres
 - `DB_NAME` – Database name
 - `TOKEN_SECRET` – Recommended: 63 random alpha-numeric characters
+- `STORAGE_PATH` – Specify a custom storage path to store the assets (optional)
 - `APP_URL` - base url for the app - [ref](http://sailsjs.org/documentation/reference/application/sails-get-base-url)
 
 To use `production.js` set `NODE_ENV` to `"production"` – so you should not set the environment variables:


### PR DESCRIPTION
Supersedes #115.

This adds the option to configure a custom storage path, which overrides the default storage path (`/tmp`).