### PR TITLE
Fixes #148 by making app channels configurable

### DIFF
--- a/api/services/ChannelService.js
+++ b/api/services/ChannelService.js
@@ -5,13 +5,7 @@
 var _ = require('lodash');
 
 var ChannelService = {
-  // Available channels ordered by desc. stability
-  availableChannels: [
-    'stable',
-    'rc',
-    'beta',
-    'alpha'
-  ]
+
 };
 
 /**
@@ -20,10 +14,10 @@ var ChannelService = {
  * @return {Array}          Applicable channel names ordered by desc. stability
  */
 ChannelService.getApplicableChannels = function(channel) {
-  var channelIndex = ChannelService.availableChannels.indexOf(channel);
+  var channelIndex = sails.config.channels.indexOf(channel);
 
   if (channelIndex === -1) {
-    return ['stable'];
+    return ChannelService.availableChannels[ChannelService.availableChannels.length - 1];
   }
 
   return ChannelService.availableChannels.slice(

--- a/assets/js/admin/add-version-modal/add-version-modal-controller.js
+++ b/assets/js/admin/add-version-modal/add-version-modal-controller.js
@@ -1,7 +1,7 @@
 angular.module('app.admin.add-version-modal', [])
-  .controller('AddVersionModalController', ['$scope', '$http', 'DataService', 'Notification', '$uibModalInstance',
-    function($scope, $http, DataService, Notification, $uibModalInstance) {
-      $scope.DataService = DataService;
+  .controller('AddVersionModalController', ['$scope', '$http', 'DataService', 'Notification', '$uibModalInstance', 'PubSub',
+    function($scope, $http, DataService, Notification, $uibModalInstance, PubSub) {
+      $scope.availableChannels = DataService.availableChannels;
 
       $scope.version = {
         name: '',
@@ -21,5 +21,22 @@ angular.module('app.admin.add-version-modal', [])
       $scope.closeModal = function() {
         $uibModalInstance.dismiss();
       };
+
+      // Watch for changes to data content and update local data accordingly.
+      var uid1 = PubSub.subscribe('data-change', function() {
+        $scope.availableChannels = DataService.availableChannels;
+
+        $scope.version = {
+          name: '',
+          notes: '',
+          channel: {
+            name: DataService.availableChannels[0]
+          }
+        };
+      });
+
+      $scope.$on('$destroy', function() {
+        PubSub.unsubscribe(uid1);
+      });
     }
   ]);

--- a/assets/js/admin/add-version-modal/add-version-modal.pug
+++ b/assets/js/admin/add-version-modal/add-version-modal.pug
@@ -36,7 +36,7 @@
           select.form-control(
             ng-model='version.channel.name',
             name='channel',
-            ng-options='o as o for o in DataService.availableChannels',
+            ng-options='o as o for o in availableChannels',
             required
             )
           hr

--- a/assets/js/admin/version-table/version-table-controller.js
+++ b/assets/js/admin/version-table/version-table-controller.js
@@ -9,9 +9,9 @@ angular.module('app.admin.version-table', [])
         }
       });
   }])
-  .controller('AdminVersionTableController', ['$scope', 'Notification', 'DataService','$uibModal',
-    function($scope, Notification, DataService, $uibModal) {
-      $scope.DataService = DataService;
+  .controller('AdminVersionTableController', ['$scope', 'Notification', 'DataService','$uibModal', 'PubSub',
+    function($scope, Notification, DataService, $uibModal, PubSub) {
+      $scope.versions = DataService.data;
 
       $scope.openEditModal = function(version, versionName) {
         var modalInstance = $uibModal.open({
@@ -37,5 +37,14 @@ angular.module('app.admin.version-table', [])
 
         modalInstance.result.then(function() {}, function() {});
       };
+
+      // Watch for changes to data content and update local data accordingly.
+      var uid1 = PubSub.subscribe('data-change', function() {
+        $scope.versions = DataService.data;
+      });
+
+      $scope.$on('$destroy', function() {
+        PubSub.unsubscribe(uid1);
+      });
     }
   ]);

--- a/assets/js/admin/version-table/version-table.pug
+++ b/assets/js/admin/version-table/version-table.pug
@@ -1,7 +1,7 @@
 .row
   h3 Version Management
         
-  table.table.table-bordered.table-hover.table-condensed.table-custom(ng-if='DataService.data.length' ng-cloak)
+  table.table.table-bordered.table-hover.table-condensed.table-custom(ng-if='versions.length' ng-cloak)
     thead
       tr
         td Name
@@ -10,7 +10,7 @@
         td Date
         td
     tbody
-      tr(data-ng-repeat='version in DataService.data')
+      tr(data-ng-repeat='version in versions')
         td {{ version.name }}
         td {{ version.channel.name }}
         td {{ version.assets.length }}
@@ -18,7 +18,7 @@
         td(style="white-space: nowrap")
           button.btn.btn-default.btn-sm(ng-click="openEditModal(version)")
             | More
-  .jumbotron(ng-hide="DataService.data.length")
+  .jumbotron(ng-hide="versions.length")
     h5.text-gray No Versions Available
 
   a.btn.btn-default(ng-click="openAddModal()") Add New Version

--- a/assets/js/download/download-controller.js
+++ b/assets/js/download/download-controller.js
@@ -55,9 +55,8 @@ angular.module('app.releases', [])
 
       // Watch for changes to data content and update local data accordingly.
       var uid1 = PubSub.subscribe('data-change', function() {
-        // $scope.$apply(function() {
         self.getLatestReleases();
-        // });
+        self.availableChannels = DataService.availableChannels;
       });
 
       // Update knowledge of the latest available versions.

--- a/config/channels.js
+++ b/config/channels.js
@@ -1,0 +1,13 @@
+/**
+ * Available release channels
+ * 
+ * These channels will be created by the app on startup.
+ * 
+ * Ordered by descending stability.
+ */
+module.exports.channels = [
+  'stable',
+  'rc',
+  'beta',
+  'alpha'
+];

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.4.3",
   "description": "A version server for hosting and serving the your electron desktop app releases.",
   "dependencies": {
+    "async": "^2.5.0",
     "bluebird": "^3.4.6",
     "bower": "^1.8.0",
     "express-useragent": "^1.0.4",


### PR DESCRIPTION
- Adds `/config/channels.js` to allow user-configured channel names
- Adds configured channels to the DB on startup if they are not present
- `DataService` in the UI loads available channels from the API on page load
- Controllers whose views show channel details subscribe to `'data-change'` events in order to update their scopes with available channels after they've been loaded by the `DataService`.