### PR TITLE
Fixes #81 by allowing multiple file types per platform

### DIFF
--- a/assets/js/admin/edit-version-modal/edit-version-modal.pug
+++ b/assets/js/admin/edit-version-modal/edit-version-modal.pug
@@ -48,6 +48,8 @@ form(editable-form='', name='versionForm', onaftersave='acceptEdit()', e-role='f
         p
           |  New installs require 
           code .exe
+          |  or 
+          code .msi
           |  assets. Updates require 
           code .nupkg
           | .
@@ -59,6 +61,18 @@ form(editable-form='', name='versionForm', onaftersave='acceptEdit()', e-role='f
           |  assets. Updates require 
           code .zip
           | .
+        h5
+          strong Linux
+        p
+          |  New installs require
+          code .deb
+          |  , 
+          code .rpm
+          |  , 
+          code .tar.gz
+          |  or 
+          code .AppImage
+          |  assets. Updates are not supported.
   .modal-footer
     div(ng-if='!versionForm.$visible')
       button.btn.btn-warning(type='button', ng-click='versionForm.$show()') Edit

--- a/assets/js/core/data/data-service.js
+++ b/assets/js/core/data/data-service.js
@@ -32,11 +32,11 @@ angular.module('app.core.data.service', [
       };
 
       self.filetypes = {
-        windows_64: '.exe',
-        windows_32: '.exe',
-        osx_64: '.dmg',
-        linux_64: '.deb',
-        linux_32: '.deb'
+        windows_64: ['.exe', '.msi'],
+        windows_32: ['.exe', '.msi'],
+        osx_64: ['.dmg', '.pkg', '.mas'],
+        linux_64: ['.deb', '.gz', '.rpm', '.AppImage'],
+        linux_32: ['.deb', '.gz', '.rpm', '.AppImage']
       };
 
       /**
@@ -597,16 +597,16 @@ angular.module('app.core.data.service', [
         _.forEach(archs, function(arch) {
           var platformName = platform + '_' + arch;
 
-          var filetype = self.filetypes[platformName];
+          var filetypes = self.filetypes[platformName];
 
-          if (!filetype) {
+          if (!filetypes) {
             return;
           }
           _.forEach(versions, function(version) {
             _.forEach(version.assets, function(asset) {
               if (
                 asset.platform === platformName &&
-                asset.filetype === filetype
+                filetypes.includes(asset.filetype)
               ) {
                 var matchedAsset = _.clone(asset);
                 matchedAsset.version = version.name;

--- a/assets/js/download/download.pug
+++ b/assets/js/download/download.pug
@@ -102,12 +102,13 @@
           ng-show="version.notes"
           ng-bind-html="version.notes"
           )
-        button.btn.btn-sm.btn-success(
+        button.btn.btn-sm.btn-success.download-btn(
           ng-repeat="asset in version.assets"
           ng-click="vm.download(asset, version.name)"
-          ng-if="asset.filetype === vm.filetypes[asset.platform]"
+          ng-if="vm.filetypes[asset.platform].includes(asset.filetype)"
           )
           | {{ vm.availablePlatforms[asset.platform] }}
+          | ({{ asset.filetype }})
 
 iframe(
   style="display:none;"

--- a/assets/styles/_custom.scss
+++ b/assets/styles/_custom.scss
@@ -231,3 +231,7 @@ input[type="number"].ng-invalid {
   border-color: red;
   color: red;
 }
+.download-btn {
+  margin-right: 10px;
+  margin-bottom: 10px;
+}


### PR DESCRIPTION
- Makes the `fileTypes` property of `DataService` an array of extensions
- Shows the file extension in the download button so the user knows what they will get
- Adds extensions to the upload version modal