### PR TITLE
Paginate available versions and return them in descending semver order

### DIFF
--- a/api/controllers/VersionController.js
+++ b/api/controllers/VersionController.js
@@ -9,6 +9,7 @@ var actionUtil = require('sails/lib/hooks/blueprints/actionUtil');
 var url = require('url');
 var Promise = require('bluebird');
 var semver = require('semver');
+var compareVersions = require('compare-versions');
 
 module.exports = {
 
@@ -28,6 +29,35 @@ module.exports = {
     }
 
     return res.redirect('/update/' + platform + '/' + version);
+  },
+
+  /**
+   * Sorts versions and returns pages sorted by by sermver
+   *
+   * ( GET /versions/sorted )
+   */
+  list: function (req, res) {
+    Version
+      .find()
+      .then(versions => {
+        var count = versions.length;
+        var page = req.param('page') || req.query.page || 0;
+        var start = page * sails.config.views.pageSize;
+        var end = start + sails.config.views.pageSize;
+        var items = versions
+          .sort(function (a, b) {
+            return -compareVersions(a.name, b.name);
+          })
+          .slice(start, end);
+
+        return res.send({
+          total: count,
+          offset: start,
+          page: page,
+          items: items
+        });
+      })
+      .catch(res.negotiate);
   },
 
   /**

--- a/assets/js/admin/version-table/version-table-controller.js
+++ b/assets/js/admin/version-table/version-table-controller.js
@@ -12,6 +12,7 @@ angular.module('app.admin.version-table', [])
   .controller('AdminVersionTableController', ['$scope', 'Notification', 'DataService','$uibModal', 'PubSub',
     function($scope, Notification, DataService, $uibModal, PubSub) {
       $scope.versions = DataService.data;
+      $scope.hasMoreVersions = DataService.hasMore;
 
       $scope.openEditModal = function(version, versionName) {
         var modalInstance = $uibModal.open({
@@ -38,9 +39,14 @@ angular.module('app.admin.version-table', [])
         modalInstance.result.then(function() {}, function() {});
       };
 
+      $scope.loadMoreVersions = function () {
+        DataService.loadMoreVersions();
+      };
+
       // Watch for changes to data content and update local data accordingly.
       var uid1 = PubSub.subscribe('data-change', function() {
         $scope.versions = DataService.data;
+        $scope.hasMoreVersions = DataService.hasMore;
       });
 
       $scope.$on('$destroy', function() {

--- a/assets/js/admin/version-table/version-table.pug
+++ b/assets/js/admin/version-table/version-table.pug
@@ -21,4 +21,6 @@
   .jumbotron(ng-hide="versions.length")
     h5.text-gray No Versions Available
 
-  a.btn.btn-default(ng-click="openAddModal()") Add New Version
+  .btn-group
+    a.btn.btn-default(ng-click="openAddModal()") Add New Version
+    a.btn.btn-default(ng-show="hasMoreVersions" ng-click="loadMoreVersions()") Load more versions

--- a/assets/js/download/download-controller.js
+++ b/assets/js/download/download-controller.js
@@ -14,6 +14,7 @@ angular.module('app.releases', [])
     ) {
       var self = this;
       self.showAllVersions = false;
+      $scope.hasMoreVersions = DataService.hasMore;
 
       self.platform = deviceDetector.os;
       if (self.platform === 'mac') {
@@ -57,6 +58,7 @@ angular.module('app.releases', [])
       var uid1 = PubSub.subscribe('data-change', function() {
         self.getLatestReleases();
         self.availableChannels = DataService.availableChannels;
+        $scope.hasMoreVersions = DataService.hasMore;
       });
 
       // Update knowledge of the latest available versions.
@@ -74,5 +76,9 @@ angular.module('app.releases', [])
       $scope.$on('$destroy', function() {
         PubSub.unsubscribe(uid1);
       });
+
+      $scope.loadMoreVersions = function () {
+        DataService.loadMoreVersions();
+      };
     }
   ]);

--- a/assets/js/download/download.pug
+++ b/assets/js/download/download.pug
@@ -109,6 +109,8 @@
           )
           | {{ vm.availablePlatforms[asset.platform] }}
           | ({{ asset.filetype }})
+      .btn-group
+        a.btn.btn-default(ng-show="vm.showAllVersions && hasMoreVersions" ng-click="loadMoreVersions()") Load more versions
 
 iframe(
   style="display:none;"

--- a/assets/styles/_custom.scss
+++ b/assets/styles/_custom.scss
@@ -235,3 +235,7 @@ input[type="number"].ng-invalid {
   margin-right: 10px;
   margin-bottom: 10px;
 }
+
+.btn-group .btn {
+  margin-right: 5px;
+}

--- a/config/routes.js
+++ b/config/routes.js
@@ -35,6 +35,8 @@ module.exports.routes = {
   'GET /update/:platform/:version/RELEASES': 'VersionController.windows',
   'GET /update/:platform/:version/:channel/RELEASES': 'VersionController.windows',
   'GET /update/:platform/:version/:channel': 'VersionController.general',
-  'GET /notes/:version?': 'VersionController.releaseNotes'
+  'GET /notes/:version?': 'VersionController.releaseNotes',
+
+  'GET /versions/sorted': 'VersionController.list'
 
 };

--- a/config/views.js
+++ b/config/views.js
@@ -31,6 +31,11 @@ module.exports.views = {
   ****************************************************************************/
 
   engine: 'pug',
-  layout: false
+  layout: false,
+
+  /**
+   * How many releases are retrieve from the API at a time
+   */
+  pageSize: 50
 
 };

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "async": "^2.5.0",
     "bluebird": "^3.4.6",
     "bower": "^1.8.0",
+    "compare-versions": "^3.1.0",
     "express-useragent": "^1.0.4",
     "fs-extra": "^1.0.0",
     "grunt": "^1.0.1",


### PR DESCRIPTION
At the moment the client-side data service requests a list of available versions, sorts them by their version numbers using semver and then shows them to the user.

The default behaviour of Sails is to return the first 30 database rows, sorted by the primary key in ascending order.  This means you'll only get the first 30 versions of your app - if you create a 31st version it will not appear in the release server UI.

This PR:

1. Fetches all the versions from the database
2. Sorts them by semver in descending order on the server side
3. Returns a page at a time to the UI (default size: 50 versions, configurable in `config/views.js`)
4. Adds a 'load more' button to the download list and version admin table

Happy to make whatever changes are required.