### PR TITLE
Parameterize the asset storage path in Docker

### DIFF
--- a/config/docker.js
+++ b/config/docker.js
@@ -38,7 +38,7 @@ module.exports = {
     token_secret: process.env['TOKEN_SECRET'],
   },
   files: {
-    dirname: '/tmp/',
+    dirname: process.env['ASSETS_PATH'] || '/tmp/',
   },
   session: {
     // Recommended: 63 random alpha-numeric characters


### PR DESCRIPTION
Leave the default /tmp/ path in place, but check for an ASSETS_PATH environment variable.  This will help avoid conflicts that arise when trying to store assets on a persistent volume outside the Docker container.