### PR TITLE
DEV-164: Added Sails call to init version updates

### DIFF
--- a/assets/js/core/data/data-service.js
+++ b/assets/js/core/data/data-service.js
@@ -542,7 +542,10 @@ angular.module('app.core.data.service', [
             $sails.get('/api/channel'),
 
             // Only sent to watch for asset updates
-            $sails.get('/api/asset')
+            $sails.get('/api/asset'),
+
+            // Only sent to watch for version updates
+            $sails.get('/api/version')
           ])
           .then(function(responses) {
             versions = responses[0];


### PR DESCRIPTION
Fixes bug introduced in [PR 166](https://github.com/ArekSredzki/electron-release-server/pull/166). The issue is that `/versions/sorted` (changed at line 537 of `data-service.js`) is not a proper [blueprint api](https://sailsjs.com/documentation/reference/blueprint-api) call and doesn’t initiate web sockets properly to monitor for updates to the version records.

This was causing the Version Management page to not dynamically update in most cases.