### PR TITLE
DEV-163: Improvements to assets

### DIFF
--- a/api/controllers/AssetController.js
+++ b/api/controllers/AssetController.js
@@ -200,7 +200,7 @@ module.exports = {
 
         var fileExt = path.extname(uploadedFile.filename);
 
-        sails.log.debug('Creating asset with name', uploadedFile.filename);
+        sails.log.debug('Creating asset with name', data.name || uploadedFile.filename);
 
         var hashPromise;
 

--- a/api/controllers/VersionController.js
+++ b/api/controllers/VersionController.js
@@ -85,6 +85,7 @@ module.exports = {
               channel: results[0][index],
               assets: results[1][index].map(function (asset) {
                 return {
+                  id: asset.id,
                   name: asset.name,
                   platform: asset.platform,
                   filetype: asset.filetype,

--- a/api/models/Asset.js
+++ b/api/models/Asset.js
@@ -9,10 +9,14 @@ module.exports = {
 
   attributes: {
 
-    name: {
+    id: {
       type: 'string',
       primaryKey: true,
-      unique: true,
+      unique: true
+    },
+
+    name: {
+      type: 'string',
       required: true
     },
 
@@ -52,5 +56,15 @@ module.exports = {
       required: true
     }
   },
-  autoPK: false
+
+  autoPK: false,
+
+  beforeCreate: (asset, proceed) => {
+    const { version, platform, filetype } = asset;
+
+    asset.id = `${version}_${platform}_${filetype.replace(/\./g, '')}`;
+
+    return proceed();
+  }
+
 };

--- a/api/services/AssetService.js
+++ b/api/services/AssetService.js
@@ -40,7 +40,7 @@ AssetService.serveFile = function(req, res, asset) {
       // Warning: not all adapters support queries
       if (_.isFunction(Asset.query)) {
         Asset.query(
-          'UPDATE asset SET download_count = download_count + 1 WHERE name = \'' + asset.name + '\';',
+          'UPDATE asset SET download_count = download_count + 1 WHERE id = \'' + asset.id + '\';',
           function(err) {
             if (err) {
               sails.log.error(
@@ -52,7 +52,7 @@ AssetService.serveFile = function(req, res, asset) {
         asset.download_count++;
 
         Asset.update({
-            name: asset.name
+            id: asset.id
           }, asset)
           .exec(function(err) {
             if (err) {
@@ -104,11 +104,11 @@ AssetService.destroy = function(asset, req) {
     throw new Error('You must pass an asset');
   }
 
-  return Asset.destroy(asset.name)
+  return Asset.destroy(asset.id)
     .then(function destroyedRecord() {
       if (sails.hooks.pubsub) {
         Asset.publishDestroy(
-          asset.name, !req._sails.config.blueprints.mirror && req, {
+          asset.id, !req._sails.config.blueprints.mirror && req, {
             previous: asset
           }
         );

--- a/assets/js/admin/add-version-asset-modal/add-version-asset-modal-controller.js
+++ b/assets/js/admin/add-version-asset-modal/add-version-asset-modal-controller.js
@@ -6,17 +6,26 @@ angular.module('app.admin.add-version-asset-modal', [])
       $scope.versionName = versionName;
 
       $scope.asset = {
+        name: '',
         platform: '',
         file: null
       };
 
       $scope.addAsset = function() {
+        if (!$scope.asset.name) {
+          delete $scope.asset.name;
+        }
+
         DataService.createAsset($scope.asset, versionName)
           .then(function success(response) {
             $uibModalInstance.close();
           }, function error(response) {
             $uibModalInstance.dismiss();
           });
+      };
+
+      $scope.updateAssetName = () => {
+        $scope.namePlaceholder = $scope.asset.file && $scope.asset.file.name;
       };
 
       $scope.closeModal = function() {

--- a/assets/js/admin/add-version-asset-modal/add-version-asset-modal.pug
+++ b/assets/js/admin/add-version-asset-modal/add-version-asset-modal.pug
@@ -7,8 +7,11 @@ form(name='assetForm', role='form')
       .form-group
         label.col-md-4.control-label(for='name') Asset Name
         .col-md-7
-          | {{ asset.file.name }}
-          span(ng-hide="asset.file.name.length").help-block Auto-populated with filename
+          input.form-control.input-md(
+            ng-model='asset.name',
+            name='name',
+            placeholder='{{ namePlaceholder || "Auto-populated with filename" }}'
+            )
       // Select platform
       .form-group
         label.col-md-4.control-label(for='platform') Platform

--- a/assets/js/admin/edit-version-asset-modal/edit-version-asset-modal-controller.js
+++ b/assets/js/admin/edit-version-asset-modal/edit-version-asset-modal-controller.js
@@ -3,10 +3,19 @@ angular.module('app.admin.edit-version-asset-modal', [])
     function($scope, DataService, Notification, $uibModalInstance, asset) {
       $scope.DataService = DataService;
 
+      $scope.originalName = asset.name;
+      $scope.fileType = asset.filetype && asset.filetype[0] === '.'
+        ? asset.filetype.replace('.', '')
+        : asset.filetype;
+
       // Clone so not to polute the original
       $scope.asset = _.cloneDeep(asset);
 
       $scope.acceptEdit = function() {
+        if (!$scope.asset.name) {
+          $scope.asset.name = $scope.originalName;
+        }
+
         DataService.updateAsset($scope.asset)
           .then(function success(response) {
             $uibModalInstance.close();
@@ -14,7 +23,7 @@ angular.module('app.admin.edit-version-asset-modal', [])
       };
 
       $scope.deleteAsset = function() {
-        DataService.deleteAsset(asset.name)
+        DataService.deleteAsset(asset.id)
           .then(function success(response) {
             $uibModalInstance.close();
           }, function error(response) {});

--- a/assets/js/admin/edit-version-asset-modal/edit-version-asset-modal.pug
+++ b/assets/js/admin/edit-version-asset-modal/edit-version-asset-modal.pug
@@ -7,7 +7,12 @@ form(editable-form='', name='assetForm', onaftersave='acceptEdit()', e-role='for
       .form-group
         label.col-md-4.control-label(for='name') Asset Name
         .col-md-7
-          | {{ asset.name }}
+          span(
+            editable-text='asset.name',
+            e-name='name',
+            e-placeholder='{{ originalName }}'
+            )
+            | {{ asset.name }}
       // Select Platform
       .form-group
         label.col-md-4.control-label(for='platform') Platform
@@ -18,6 +23,11 @@ form(editable-form='', name='assetForm', onaftersave='acceptEdit()', e-role='for
             e-ng-options='key as value for (key, value) in DataService.availablePlatforms',
             )
             | {{ DataService.availablePlatforms[asset.platform] || 'Not set' }}
+      // File Type
+      .form-group(ng-show="fileType")
+        label.col-md-4.control-label File Type
+        .col-md-7
+          | {{ fileType }}
   .modal-footer
     div(ng-if='!assetForm.$visible')
       button.btn.btn-warning(type='button', ng-click='assetForm.$show()') Edit

--- a/assets/js/core/data/data-service.js
+++ b/assets/js/core/data/data-service.js
@@ -357,11 +357,11 @@ angular.module('app.core.data.service', [
         if (!asset) {
           throw new Error('A asset object is required for updating');
         }
-        if (!asset.name) {
+        if (!asset.id) {
           throw new Error('The passed asset object must have been submitted to the database in order to be updated');
         }
 
-        return $http.post('/api/asset/' + asset.name, asset)
+        return $http.post('/api/asset/' + asset.id, asset)
           .then(function(response) {
             Notification.success('Asset Updated Successfully.');
 
@@ -467,7 +467,7 @@ angular.module('app.core.data.service', [
 
           versionIndex = _.findIndex(self.data, function(version) {
             index = _.findIndex(version.assets, {
-              name: msg.id // Sails sends back the old id for us
+              id: msg.id // Sails sends back the old id for us
             });
 
             return index !== -1;
@@ -493,7 +493,7 @@ angular.module('app.core.data.service', [
           versionIndex = _.findIndex(self.data, function(version) {
             $log.log('Searching Version:', version);
             index = _.findIndex(version.assets, {
-              name: msg.id // Sails sends back the old id for us
+              id: msg.id // Sails sends back the old id for us
             });
             $log.log('result:', index);
 

--- a/migrations/20190930000000-asset-migration.js
+++ b/migrations/20190930000000-asset-migration.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const { driver } = require('db-migrate').getInstance().config.getCurrent().settings;
+
+const sql = {
+
+  // PostgreSQL
+  pg: {
+    up: (
+
+      // Add `id` column (if doesn't exist) to `asset` table
+      'ALTER TABLE asset ADD COLUMN IF NOT EXISTS id TEXT;' +
+
+      // Populate `id` column in `asset` table with default data if empty
+      'UPDATE asset SET id = CONCAT(version, \'_\', platform, \'_\', REPLACE(filetype, \'.\', \'\')) WHERE id IS NULL;' +
+
+      // Drop primary key constraint (if exists) from `asset` table
+      'ALTER TABLE asset DROP CONSTRAINT IF EXISTS asset_pkey;' +
+
+      // Add primary key constraint on `id` column in `asset` table
+      'ALTER TABLE asset ADD PRIMARY KEY (id);'
+
+    ),
+    down: (
+
+      // Drop `id` column (if exists) from `asset` table
+      'ALTER TABLE asset DROP COLUMN IF EXISTS id;' +
+
+      // Drop primary key constraint (if exists) from `asset` table
+      'ALTER TABLE asset DROP CONSTRAINT IF EXISTS asset_pkey;' +
+
+      // Add primary key constraint on `name` column in `asset` table
+      'ALTER TABLE asset ADD PRIMARY KEY (name);'
+
+    )
+  }
+
+};
+
+const { up } = driver && sql[driver];
+const { down } = driver && sql[driver];
+
+exports.up = db => up ? db.runSql(up) : null;
+exports.down = db => down ? db.runSql(down) : null;


### PR DESCRIPTION
**Changes**
- Allow specifying name during asset creation
    - If not specified then uses filename like previously
- Allow editing asset names
    - If input is empty then name remains as it was
- Display asset file extension name in Edit Asset Modal
- Change assets PK to come from a combination of version, platform & file type
- Created migration script (requires [db-migrate PR](https://github.com/ArekSredzki/electron-release-server/pull/201))
- Now only allows 1 unique asset per version of a specific platform & file type
    - Before it would allow adding many assets of the same platform & file type as long as the name was different, but this didn’t work well because the Download page would show multiple (unidentifiable) entries and whichever you clicked it would give you the same file, even though the URL would be different. The file it would serve was whatever the newest asset was that matched the platform & file type.
    - File names do NOT have to be unique anymore

**Add New Asset Modal (Empty)**

![image](https://user-images.githubusercontent.com/16656318/66017894-94d6b280-e491-11e9-819f-ef2db7f2d107.png)

**Add New Asset Modal (After selecting file)**

![image](https://user-images.githubusercontent.com/16656318/66017918-b9cb2580-e491-11e9-9cf8-4659c9dbdb66.png)

**Add New Asset Modal (With custom file name)**

![image](https://user-images.githubusercontent.com/16656318/66017913-b20b8100-e491-11e9-81d8-bfeaa8fb63b2.png)

**Edit Version Modal (With asset added)**

![image](https://user-images.githubusercontent.com/16656318/66017930-cc455f00-e491-11e9-8ceb-e0e411ac90de.png)

**Edit Asset Modal (Not in edit mode)**

![image](https://user-images.githubusercontent.com/16656318/66017967-ee3ee180-e491-11e9-9a37-1d4adf83368e.png)

**Edit Asset Modal (In edit mode)**

![image](https://user-images.githubusercontent.com/16656318/66017988-0282de80-e492-11e9-94f5-d431d38d3288.png)
