### PR TITLE
DEV-162: Added availability date for versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ If you host your project on your Github **and** do not need a UI for your app, t
     - Mac uses `*.dmg` and `*.zip`
     - Windows uses `*.exe` and `*.nupkg`
 - :sparkles: Serve the perfect type of assets: `.zip` for Squirrel.Mac, `.nupkg` for Squirrel.Windows, `.dmg` for Mac users, ...
+- :sparkles: Specify date of availability for releases
 - :sparkles: Release notes endpoint
     - `/notes/:version`
 

--- a/api/models/Version.js
+++ b/api/models/Version.js
@@ -25,10 +25,28 @@ module.exports = {
       required: true
     },
 
+    availability: {
+      type: 'datetime',
+      required: true
+    },
+
     notes: {
       type: 'string'
     }
   },
-  autoPK: false
+
+  autoPK: false,
+
+  afterCreate: (version, proceed) => {
+    const { availability, createdAt, name } = version;
+
+    if (new Date(availability) < new Date(createdAt)) {
+      return Version
+        .update(name, { availability: createdAt })
+        .exec(proceed);
+    }
+
+    return proceed();
+  }
 
 };

--- a/assets/js/admin/add-version-asset-modal/add-version-asset-modal-controller.js
+++ b/assets/js/admin/add-version-asset-modal/add-version-asset-modal-controller.js
@@ -1,9 +1,10 @@
 angular.module('app.admin.add-version-asset-modal', [])
-  .controller('AddVersionAssetModalController', ['$scope', 'DataService', '$uibModalInstance', 'versionName',
-    function($scope, DataService, $uibModalInstance, versionName) {
+  .controller('AddVersionAssetModalController', ['$scope', 'DataService', '$uibModalInstance', 'version',
+    ($scope, DataService, $uibModalInstance, version) => {
       $scope.DataService = DataService;
 
-      $scope.versionName = versionName;
+      $scope.versionName = version.name;
+      $scope.versionIsAvailable = DataService.checkAvailability(version);
 
       $scope.asset = {
         name: '',
@@ -16,7 +17,7 @@ angular.module('app.admin.add-version-asset-modal', [])
           delete $scope.asset.name;
         }
 
-        DataService.createAsset($scope.asset, versionName)
+        DataService.createAsset($scope.asset, version.name)
           .then(function success(response) {
             $uibModalInstance.close();
           }, function error(response) {

--- a/assets/js/admin/add-version-asset-modal/add-version-asset-modal.pug
+++ b/assets/js/admin/add-version-asset-modal/add-version-asset-modal.pug
@@ -38,7 +38,7 @@ form(name='assetForm', role='form')
             )
   .modal-footer
     .modal-footer-note.col-md-7
-      span.text-gray(ng-show='!asset.file.progress')
+      span.text-gray(ng-show='!asset.file.progress && versionIsAvailable')
         | This file will be live once uploaded.
       uib-progressbar.progress-striped.active(
         type="success"

--- a/assets/js/admin/add-version-modal/add-version-modal-controller.js
+++ b/assets/js/admin/add-version-modal/add-version-modal-controller.js
@@ -1,14 +1,16 @@
 angular.module('app.admin.add-version-modal', [])
-  .controller('AddVersionModalController', ['$scope', '$http', 'DataService', 'Notification', '$uibModalInstance', 'PubSub',
-    function($scope, $http, DataService, Notification, $uibModalInstance, PubSub) {
+  .controller('AddVersionModalController', ['$scope', '$http', 'DataService', 'Notification', '$uibModalInstance', 'PubSub', 'moment',
+    ($scope, $http, DataService, Notification, $uibModalInstance, PubSub, moment) => {
       $scope.availableChannels = DataService.availableChannels;
+      $scope.currentDateTime = moment().startOf('second').toDate();
 
       $scope.version = {
         name: '',
         notes: '',
         channel: {
           name: DataService.availableChannels[0]
-        }
+        },
+        availability: $scope.currentDateTime
       };
 
       $scope.addVersion = function() {
@@ -31,7 +33,8 @@ angular.module('app.admin.add-version-modal', [])
           notes: '',
           channel: {
             name: DataService.availableChannels[0]
-          }
+          },
+          availability: $scope.currentDateTime
         };
       });
 

--- a/assets/js/admin/add-version-modal/add-version-modal.pug
+++ b/assets/js/admin/add-version-modal/add-version-modal.pug
@@ -40,6 +40,18 @@
             )
           hr
           span.help-block You will not be able to change the above later.
+      // Availability Date
+      .form-group
+        label.col-md-4.control-label(for='availability') Availability Date
+        .col-md-7
+          input.form-control.input-md(
+            ng-model='version.availability',
+            name='availability',
+            type='datetime-local',
+            min='{{ currentDateTime }}',
+            step='1',
+            required
+            )
       // Change Notes
       .form-group
         label.col-md-4.control-label(for='notes') Change Notes

--- a/assets/js/admin/edit-version-modal/edit-version-modal.pug
+++ b/assets/js/admin/edit-version-modal/edit-version-modal.pug
@@ -11,6 +11,18 @@ form(editable-form='', name='versionForm', onaftersave='acceptEdit()', e-role='f
       .form-group
         label.col-md-4.control-label Channel
         .col-md-7 {{ version.channel.name || 'Not set' }}
+      // Availability Date
+      .form-group
+        label.col-md-4.control-label(for='availability') Availability Date
+        .col-md-7
+          span(
+            editable-text='version.availability',
+            e-name='availability',
+            e-type='datetime-local',
+            e-min='{{ createdAt }}',
+            e-step='1'
+            )
+            p {{ version.availability | amDateFormat: 'YYYY-MM-DD, hh:mm:ss A' }}
       // Notes
       .form-group
         label.col-md-4.control-label(for='notes') Change Notes
@@ -75,6 +87,7 @@ form(editable-form='', name='versionForm', onaftersave='acceptEdit()', e-role='f
           |  assets. Updates are not supported.
   .modal-footer
     div(ng-if='!versionForm.$visible')
+      button.btn.btn-warning.pull-left(ng-hide='isAvailable', type='button', ng-click='makeAvailable()') Make Available
       button.btn.btn-warning(type='button', ng-click='versionForm.$show()') Edit
       button.btn.btn-danger(type='button', ng-click='deleteVersion()', confirm='Are you sure that you want to delete this version?') Delete
       button.btn.btn-default(type='button', ng-click='closeModal()') Close

--- a/assets/js/admin/version-table/version-table.pug
+++ b/assets/js/admin/version-table/version-table.pug
@@ -8,6 +8,7 @@
         td Channel
         td Asset Count
         td Date
+        td Availability
         td
     tbody
       tr(data-ng-repeat='version in versions')
@@ -15,6 +16,7 @@
         td {{ version.channel.name }}
         td {{ version.assets.length }}
         td(am-time-ago="version.createdAt")
+        td(am-time-ago="version.availability")
         td(style="white-space: nowrap")
           button.btn.btn-default.btn-sm(ng-click="openEditModal(version)")
             | More

--- a/assets/js/download/download-controller.js
+++ b/assets/js/download/download-controller.js
@@ -51,7 +51,7 @@ angular.module('app.releases', [])
           self.archs,
           self.channel
         );
-        self.versions = DataService.data;
+        self.versions = DataService.data.filter(DataService.checkAvailability);
       };
 
       // Watch for changes to data content and update local data accordingly.

--- a/config/bootstrap.js
+++ b/config/bootstrap.js
@@ -9,29 +9,43 @@
  * http://sailsjs.org/#!/documentation/reference/sails.config/sails.config.bootstrap.html
  */
 
- const mapSeries = require('async/mapSeries');
- const waterfall = require('async/waterfall');
- const apply = require('async/apply');
+const mapSeries = require('async/mapSeries');
+const waterfall = require('async/waterfall');
+const series = require('async/series');
 
-module.exports.bootstrap = function(cb) {  
-  // Create configured channels in database
-  mapSeries(sails.config.channels, (name, next) => {
-    waterfall([
-      (next) => {
-        Channel.find({
-          name: name
-        }).exec(next);
-      },
-      (result, next) => {
-        if (result.length) {
-          return next();
+module.exports.bootstrap = done => {
+  series([
+
+    // Create configured channels in database
+    cb => mapSeries(sails.config.channels, (name, next) => {
+      waterfall([
+        next => {
+          Channel
+            .find(name)
+            .exec(next);
+        },
+        (result, next) => {
+          if (result.length) return next();
+
+          Channel
+            .create({ name })
+            .exec(next);
         }
+      ], next);
+    }, cb),
 
-        Channel.create({
-          name: name
-        })
-        .exec(next);
-      }
-    ], next);
-  }, cb);
+    // Populate existing versions without availability date using version creation date
+    cb => Version
+      .find({ availability: null })
+      .then(versions => mapSeries(
+        versions,
+        ({ name, createdAt }, next) => {
+          Version
+            .update(name, { availability: createdAt })
+            .exec(next)
+        },
+        cb
+      ))
+
+  ], done);
 };

--- a/config/policies.js
+++ b/config/policies.js
@@ -45,6 +45,7 @@ module.exports.policies = {
     create: 'authToken',
     update: 'authToken',
     delete: 'authToken',
+    availability: 'authToken',
     redirect: 'noCache',
     general: 'noCache',
     windows: 'noCache',

--- a/config/routes.js
+++ b/config/routes.js
@@ -29,6 +29,8 @@ module.exports.routes = {
   '/auth/login': { view: 'homepage' },
   '/auth/logout': { view: 'homepage' },
 
+  'PUT /version/availability/:version/:timestamp': 'VersionController.availability',
+
   'GET /download/latest/:platform?': 'AssetController.download',
   'GET /download/channel/:channel/:platform?': 'AssetController.download',
   'GET /download/:version/:platform?/:filename?': 'AssetController.download',

--- a/docs/api.md
+++ b/docs/api.md
@@ -14,6 +14,11 @@ GET http://download.myapp.com/api/version
 GET http://download.myapp.com/api/version/1.1.0
 ```
 
+#### Set availability date of specific version (Unix timestamp in milliseconds):
+```
+PUT http://download.myapp.com/version/availability/1.1.0/1574755200000
+```
+
 #### List channels:
 ```
 GET http://download.myapp.com/api/channel

--- a/migrations/20190930000000-availability-migration.js
+++ b/migrations/20190930000000-availability-migration.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const { driver } = require('db-migrate').getInstance().config.getCurrent().settings;
+
+const sql = {
+
+  // PostgreSQL
+  pg: {
+    up: (
+
+      // Add `availability` column (if doesn't exist) to `version` table
+      'ALTER TABLE version ADD COLUMN IF NOT EXISTS availability TIMESTAMPTZ;'
+
+    ),
+    down: (
+
+      // Drop `availability` column (if exists) from `version` table
+      'ALTER TABLE version DROP COLUMN IF EXISTS availability;'
+
+    )
+  }
+
+};
+
+const { up } = driver && sql[driver];
+const { down } = driver && sql[driver];
+
+exports.up = db => up ? db.runSql(up) : null;
+exports.down = db => down ? db.runSql(down) : null;


### PR DESCRIPTION
**Changes/Notes**
- Added the ability to set/edit a date of availability for each version
- Updating can be done via the UI or the API
- API uses unix timestamp in milliseconds
- Created migration script (requires [db-migrate PR](https://github.com/ArekSredzki/electron-release-server/pull/201))
- If the version is not yet available it will not show in the UI (except in Admin) and will not be sent as a response to calls from the api

**New Version**
- Availability date can be any time after the opening of the New Version modal
- If the availability date ends up being some time between when the modal is opened and when the record is created, then the availability date is automatically set to the creation date
- The date/time picker is using the built in HTML 5 input `datetime-local`

![image](https://user-images.githubusercontent.com/16656318/66018965-192b3480-e496-11e9-829f-f5e24b3a518a.png)

**Version Management**

![image](https://user-images.githubusercontent.com/16656318/66018945-03b60a80-e496-11e9-8065-ec81276032f4.png)

**Edit Version (Not in edit mode)**
- Date is editable from this dialog after pressing `Edit`
- Added `Make Available` button to Edit Version modal which sets the availability date to the current date/time

![image](https://user-images.githubusercontent.com/16656318/66018978-25af8d00-e496-11e9-9887-22c3bcb79aa6.png)

**Edit Version (In edit mode)**

![image](https://user-images.githubusercontent.com/16656318/66019008-437cf200-e496-11e9-9c39-11b3d15d639a.png)