### PR TITLE
DEV-167: Fixes various 404 responses

### DIFF
--- a/assets/js/download/download.pug
+++ b/assets/js/download/download.pug
@@ -118,5 +118,5 @@ iframe(
   width="1"
   height="1"
   frameborder="0"
-  src="{{vm.downloadUrl}}"
+  ng-src="{{vm.downloadUrl}}"
   )

--- a/config/routes.js
+++ b/config/routes.js
@@ -22,9 +22,12 @@
 
 module.exports.routes = {
 
-  '/': {
-    view: 'homepage'
-  },
+  '/': { view: 'homepage' },
+  '/home': { view: 'homepage' },
+  '/releases/:channel?': { view: 'homepage' },
+  '/admin': { view: 'homepage' },
+  '/auth/login': { view: 'homepage' },
+  '/auth/logout': { view: 'homepage' },
 
   'GET /download/latest/:platform?': 'AssetController.download',
   'GET /download/channel/:channel/:platform?': 'AssetController.download',


### PR DESCRIPTION
**Changes**
- Changed iframe src to use [ng-src](https://docs.angularjs.org/api/ng/directive/ngSrc) so it doesn't load the literal `{{vm.downloadUrl}}` string before Angular has time to replace it
- Added [explicit routes](https://sailsjs.com/documentation/concepts/routes#?custom-routes) so that loading these URL's doesn't cause a 404 response.