### PR TITLE
DEV-168: Fix releases when accessing directly

### DIFF
--- a/assets/js/download/download-controller.js
+++ b/assets/js/download/download-controller.js
@@ -38,7 +38,7 @@ angular.module('app.releases', [])
 
       // Get selected channel from route or set to default (stable)
       self.channel = $routeParams.channel || self.setChannelParams(
-        self.availableChannels[0]
+        (self.availableChannels && self.availableChannels[0]) || 'stable'
       );
 
       self.latestReleases = null;


### PR DESCRIPTION
Going directly to `/releases` would cause an error because `DataService.initialize` had not yet completed and that function populates `DataService.availableChannels` which is what `self.availableChannels` is assigned from. This error would only occur if you directly went to `/releases` with no appended channel, as `self.availableChannels` was undefined.