### PR TITLE
Fix issue with loading when DATABASE_URL is unset

### DIFF
--- a/config/docker.js
+++ b/config/docker.js
@@ -25,11 +25,11 @@ module.exports = {
   connections: {
     postgresql: {
       adapter: 'sails-postgresql',
-      host: process.env['DB_HOST'] || process.env['DATABASE_URL'].split('@')[1].split(':')[0],
-      port: process.env['DB_PORT'] || process.env['DATABASE_URL'].split('@')[1].split(':')[1].split('/')[0],
-      user: process.env['DB_USERNAME'] || process.env['DATABASE_URL'].split('@')[0].split(':')[1].split('/')[2],
-      password: process.env['DB_PASSWORD'] || process.env['DATABASE_URL'].split('@')[0].split(':')[2],
-      database: process.env['DB_NAME'] || process.env['DATABASE_URL'].split('/')[3]
+      host: process.env['DB_HOST'] || process.env['DATABASE_URL'] && process.env['DATABASE_URL'].split('@')[1].split(':')[0],
+      port: process.env['DB_PORT'] || process.env['DATABASE_URL'] && process.env['DATABASE_URL'].split('@')[1].split(':')[1].split('/')[0],
+      user: process.env['DB_USERNAME'] || process.env['DATABASE_URL'] && process.env['DATABASE_URL'].split('@')[0].split(':')[1].split('/')[2],
+      password: process.env['DB_PASSWORD'] || process.env['DATABASE_URL'] && process.env['DATABASE_URL'].split('@')[0].split(':')[2],
+      database: process.env['DB_NAME'] || process.env['DATABASE_URL'] && process.env['DATABASE_URL'].split('/')[3]
     }
   },
   jwt: {
@@ -44,11 +44,11 @@ module.exports = {
     // Recommended: 63 random alpha-numeric characters
     // Generate using: https://www.grc.com/passwords.htm
     token_secret: process.env['TOKEN_SECRET'],
-    database: process.env['DB_NAME'] || process.env['DATABASE_URL'].split('/')[3],
-    host: process.env['DB_HOST'] || process.env['DATABASE_URL'].split('@')[1].split(':')[0],
-    user: process.env['DB_USERNAME'] || process.env['DATABASE_URL'].split('@')[0].split(':')[1].split('/')[2],
-    password: process.env['DB_PASSWORD'] || process.env['DATABASE_URL'].split('@')[0].split(':')[2],
-    port: process.env['DB_PORT'] || process.env['DATABASE_URL'].split('@')[1].split(':')[1].split('/')[0]
+    database: process.env['DB_NAME'] || process.env['DATABASE_URL'] && process.env['DATABASE_URL'].split('/')[3],
+    host: process.env['DB_HOST'] || process.env['DATABASE_URL'] && process.env['DATABASE_URL'].split('@')[1].split(':')[0],
+    user: process.env['DB_USERNAME'] || process.env['DATABASE_URL'] && process.env['DATABASE_URL'].split('@')[0].split(':')[1].split('/')[2],
+    password: process.env['DB_PASSWORD'] || process.env['DATABASE_URL'] && process.env['DATABASE_URL'].split('@')[0].split(':')[2],
+    port: process.env['DB_PORT'] || process.env['DATABASE_URL'] && process.env['DATABASE_URL'].split('@')[1].split(':')[1].split('/')[0]
   }
 
 };


### PR DESCRIPTION
As noticed in issue [208](https://github.com/ArekSredzki/electron-release-server/issues/208), trying to load via `npm start` was not working even with a properly configured `local.js` file. An issue I found that was stopping it from working for me was that I did not have `DATABASE_URL` set in my local environment, so I was getting the error:
```shell
Details:TypeError: Cannot read property 'split' of undefined
    at Object.<anonymous> (/Users/dustin/Git/electron-release-server/config/docker.js:28:67)
```

I've added a check for `DATABASE_URL` in the environment before trying to split it.