### PR TITLE
Change to `uglify-es` to fix prod builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "grunt-contrib-jst": "~1.0.0",
     "grunt-contrib-less": "1.4.0",
     "grunt-contrib-pug": "^1.0.0",
-    "grunt-contrib-uglify": "~2.0.0",
+    "grunt-contrib-uglify-es": "^3.3.0",
     "grunt-contrib-watch": "~1.0.0",
     "grunt-sails-linker": "~1.0.4",
     "grunt-sass": "^2.0.0",

--- a/tasks/config/uglify.js
+++ b/tasks/config/uglify.js
@@ -18,5 +18,5 @@ module.exports = function(grunt) {
 		}
 	});
 
-	grunt.loadNpmTasks('grunt-contrib-uglify');
+	grunt.loadNpmTasks('grunt-contrib-uglify-es');
 };


### PR DESCRIPTION
As @ArekSredzki [mentioned](https://github.com/ArekSredzki/electron-release-server/pull/202#issuecomment-538785568), there is indeed an issue with `uglify` when building for prod. Luckily a different version exists called `uglify-es` which fixes this issue. I was able to get things going with this version.