### PR TITLE
Version updates in Dockerfile and docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM node:6
+FROM node:10
 
 # Create app directory
-RUN mkdir -p /usr/src/electron-release-server
 WORKDIR /usr/src/electron-release-server
 
 # Install app dependencies
 COPY package.json .bowerrc bower.json /usr/src/electron-release-server/
 RUN npm install \
   && ./node_modules/.bin/bower install --allow-root \
-  && npm cache clean
+  && npm cache clean --force \
+  && npm prune --production
 
 # Bundle app source
 COPY . /usr/src/electron-release-server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - '5000:80'
     entrypoint: ./scripts/wait.sh db:5432 -- npm start
   db:
-    image: postgres
+    image: postgres:11
     environment:
       POSTGRES_PASSWORD: secret
       POSTGRES_USER: releaseserver


### PR DESCRIPTION
Two minor updates to the Dockerfile and docker-compose.yml:

Dockerfile still references node:6, which recently lost LTS. 

docker-compose.yml references postgres, which defaults to `latest`, currently `postgres:12`. However, this seemed to cause the following error: 

```
db_1   | 2019-11-05 11:58:46.469 UTC [34] ERROR:  column r.consrc does not exist at character 212
db_1   | 2019-11-05 11:58:46.469 UTC [34] HINT:  Perhaps you meant to reference the column "r.conkey" or the column "r.conbin".
db_1   | 2019-11-05 11:58:46.469 UTC [34] STATEMENT:  SELECT x.nspname || '.' || x.relname as "Table", x.attnum as "#", x.attname as "Column", x."Type", case x.attnotnull when true then 'NOT NULL' else '' end as "NULL", r.conname as "Constraint", r.contype as "C", r.consrc, fn.nspname || '.' || f.relname as "F Key", d.adsrc as "Default" FROM (SELECT c.oid, a.attrelid, a.attnum, n.nspname, c.relname, a.attname, pg_catalog.format_type(a.atttypid, a.atttypmod) as "Type", a.attnotnull FROM pg_catalog.pg_attribute a, pg_namespace n, pg_class c WHERE a.attnum > 0 AND NOT a.attisdropped AND a.attrelid = c.oid and c.relkind not in ('S','v') and c.relnamespace = n.oid and n.nspname not in ('pg_catalog','pg_toast','information_schema')) x left join pg_attrdef d on d.adrelid = x.attrelid and d.adnum = x.attnum left join pg_constraint r on r.conrelid = x.oid and r.conkey[1] = x.attnum left join pg_class f on r.confrelid = f.oid left join pg_namespace fn on f.relnamespace = fn.oid where x.relname = 'asset' and x.nspname = 'public' order by 1,2;
```

Forcing postgres to `postgres:11` fixed this. Similar issue here: https://github.com/pantsel/konga/issues/462