### PR TITLE
Fix bug in asset's semver comparison

### DIFF
--- a/api/controllers/VersionController.js
+++ b/api/controllers/VersionController.js
@@ -399,15 +399,18 @@ module.exports = {
                     function(asset) {
                       return asset.filetype === '.nupkg'
                         && _.includes(asset.name.toLowerCase(), '-delta')
-                        && semver.lte(version, asset.version)
-                        && semver.gt(latestVersion.name, asset.version);
+                        && semver.lte(version, VersionService.clearAssetVersion(asset.version))
+                        && semver.gt(latestVersion.name, VersionService.clearAssetVersion(asset.version));
                     }));
               }, []);
 
             Array.prototype.unshift.apply(latestVersion.assets, deltaAssets);
 
             latestVersion.assets.sort(function(a1, a2) {
-              return semver.compare(a1.version, a2.version);
+              return semver.compare(
+                VersionService.clearAssetVersion(a1.version),
+                VersionService.clearAssetVersion(a2.version)
+              );
             });
 
             sails.log.debug('Latest Windows Version', latestVersion);

--- a/api/services/VersionService.js
+++ b/api/services/VersionService.js
@@ -24,6 +24,11 @@ VersionService.compare = function(v1, v2) {
   return 0;
 };
 
+// Remove flavor from asset version
+VersionService.clearAssetVersion = function(version) {
+  return version.replace(/_.*/, '');
+};
+
 /**
  * Deletes a version from the database.
  * @param   {Object}  version The versions record object from sails


### PR DESCRIPTION
As stated in api.md asset version id is formatted as `name_flavor`, resulting in `TypeError: Invalid version: 0.0.2_default` when more than one latestVersion asset is available.