### PR TITLE
Fix for nupkg assets id duplication

### DIFF
--- a/api/controllers/AssetController.js
+++ b/api/controllers/AssetController.js
@@ -210,11 +210,13 @@ module.exports = {
             sails.log.debug('Creating asset with name', data.name || uploadedFile.filename);
 
             var hashPromise;
+            var packageType;
 
             if (fileExt === '.nupkg') {
               // Calculate the hash of the file, as it is necessary for windows
               // files
               hashPromise = AssetService.getHash(uploadedFile.fd);
+              packageType = AssetService.getPackageType(uploadedFile.filename);
             } else if (fileExt === '.exe' || fileExt === '.zip') {
               hashPromise = AssetService.getHash(uploadedFile.fd, 'sha256');
             } else {
@@ -229,6 +231,7 @@ module.exports = {
                     name: uploadedFile.filename,
                     hash: fileHash,
                     filetype: fileExt,
+                    package_type: packageType,
                     fd: uploadedFile.fd,
                     size: uploadedFile.size
                   }, data))

--- a/api/models/Asset.js
+++ b/api/models/Asset.js
@@ -31,6 +31,10 @@ module.exports = {
       required: true
     },
 
+    package_type: {
+      type: 'string'
+    },
+
     hash: {
       type: 'string'
     },
@@ -60,9 +64,11 @@ module.exports = {
   autoPK: false,
 
   beforeCreate: (asset, proceed) => {
-    const { version, platform, filetype } = asset;
+    const { version, platform, filetype, package_type } = asset;
 
-    asset.id = `${version}_${platform}_${filetype.replace(/\./g, '')}`;
+    asset.id = [version, platform, filetype.replace(/\./g, ''), package_type]
+      .filter(arg => arg)
+      .join('_');
 
     return proceed();
   }

--- a/api/services/AssetService.js
+++ b/api/services/AssetService.js
@@ -90,6 +90,17 @@ AssetService.getHash = function(fd, type = 'sha1') {
   });
 };
 
+/**
+ * Returns nupkg type (full, delta) from filename
+ */
+AssetService.getPackageType = function(filename) {
+  var matches = filename.match(/.*-(\w+)\.nupkg/);
+
+  return matches && matches.length === 2
+    ? matches[1]
+    : undefined;
+}
+
 
 /**
  * Deletes an asset from the database.

--- a/migrations/20200520000000-asset-package-type-migration copy.js
+++ b/migrations/20200520000000-asset-package-type-migration copy.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const { driver } = require('db-migrate').getInstance().config.getCurrent().settings;
+
+const sql = {
+
+  // PostgreSQL
+  pg: {
+    up: (
+
+      // Add `package_type` column (if doesn't exist) to `asset` table
+      'ALTER TABLE asset ADD COLUMN IF NOT EXISTS package_type TEXT;'
+
+    ),
+    down: (
+
+
+      // Drop `package_type` column (if exists) from `asset` table
+      'ALTER TABLE asset DROP COLUMN IF EXISTS package_type;'
+
+    )
+  }
+
+};
+
+const { up } = driver && sql[driver];
+const { down } = driver && sql[driver];
+
+exports.up = db => up ? db.runSql(up) : null;
+exports.down = db => down ? db.runSql(down) : null;


### PR DESCRIPTION
Problem:
I upload full and delta nupkg files, only one is inserted because generated asset's ids are equal.
Proposed solution:
Include nupkg type in asset id.

I would like to discuss this solution because I don't have an experience with Sails.js and new to the project.
Also I have concerns about migration, not sure if we should or not update old records. And if server is run in container it's required to attach into and run migration up - it seems that migrations should be applied at container start.