### PR TITLE
Support macos arm64

### DIFF
--- a/api/models/Asset.js
+++ b/api/models/Asset.js
@@ -22,7 +22,7 @@ module.exports = {
 
     platform: {
       type: 'string',
-      enum: ['linux_32', 'linux_64', 'osx_64', 'windows_32', 'windows_64'],
+      enum: ['linux_32', 'linux_64', 'osx_64', 'osx_arm64', 'windows_32', 'windows_64'],
       required: true
     },
 

--- a/api/services/PlatformService.js
+++ b/api/services/PlatformService.js
@@ -38,7 +38,7 @@ PlatformService.detectFromRequest = function(req) {
   var ua = useragent.parse(source);
 
   if (ua.isWindows) return [this.WINDOWS_32, this.WINDOWS_64];
-  if (ua.isMac) return [this.OSX_64];
+  if (ua.isMac) return [this.OSX_64, this.OSX_ARM64]; // this.OSX_ARM64 until a bug with arm64 useragent is fixed
   if (ua.isLinux64) return [this.LINUX_64, this.LINUX_32];
   if (ua.isLinux) return [this.LINUX_32];
 };

--- a/api/services/PlatformService.js
+++ b/api/services/PlatformService.js
@@ -12,6 +12,7 @@ var PlatformService = {
   OSX: 'osx',
   OSX_32: 'osx_32',
   OSX_64: 'osx_64',
+  OSX_ARM64: 'osx_arm64',
   WINDOWS: 'windows',
   WINDOWS_32: 'windows_32',
   WINDOWS_64: 'windows_64',
@@ -82,7 +83,11 @@ PlatformService.detect = function(platformName, strictMatch) {
     // _.includes(name, 'amd64') ||
     _.includes(name, '64')
   ) {
-    suffixes.push('64');
+    if (_.includes(name, 'arm64')) {
+      suffixes.unshift('arm64');
+    } else {
+      suffixes.push('64');
+    }
 
     if (!strictMatch && prefix !== this.OSX) {
       suffixes.unshift('32');

--- a/assets/js/core/data/data-service.js
+++ b/assets/js/core/data/data-service.js
@@ -26,7 +26,8 @@ angular.module('app.core.data.service', [
       self.availablePlatforms = {
         windows_64: 'Windows 64 bit',
         windows_32: 'Windows 32 bit',
-        osx_64: 'OS X 64 bit',
+        osx_64: 'OS X 64 bit Intel',
+        osx_arm64: 'OS X 64 bit ARM',
         linux_64: 'Linux 64 bit',
         linux_32: 'Linux 32 bit'
       };
@@ -35,6 +36,7 @@ angular.module('app.core.data.service', [
         windows_64: ['.exe', '.msi'],
         windows_32: ['.exe', '.msi'],
         osx_64: ['.dmg', '.pkg', '.mas'],
+        osx_arm64: ['.dmg', '.pkg', '.mas'],
         linux_64: ['.deb', '.gz', '.rpm', '.AppImage'],
         linux_32: ['.deb', '.gz', '.rpm', '.AppImage']
       };

--- a/assets/js/download/download-controller.js
+++ b/assets/js/download/download-controller.js
@@ -19,7 +19,7 @@ angular.module('app.releases', [])
       self.platform = deviceDetector.os;
       if (self.platform === 'mac') {
         self.platform = 'osx';
-        self.archs = ['64'];
+        self.archs = ['64', 'arm64'];
       } else {
         self.archs = ['32', '64'];
       }

--- a/assets/js/download/download.pug
+++ b/assets/js/download/download.pug
@@ -16,10 +16,10 @@
           ng-change='vm.getLatestReleases()'
           )
 .row.text-center.padding-top-20(ng-if="vm.latestReleases")
-  .col-md-12(ng-if="vm.platform === 'osx'")
+  .col-md-12(ng-if="vm.platform === 'osx' && !vm.archs.includes('arm64')")
     .jumbotron
       h4 OS X 
-        span.text-muted 64 bit
+        span.text-muted 64 bit INTEL
       a.btn.btn-success.btn-lg(
         ng-click="vm.download(vm.latestReleases['64'])"
         )
@@ -35,6 +35,26 @@
         h4 Change Notes
         p.release-notes.text-muted(
           ng-bind="vm.latestReleases['64'].notes"
+          )
+  .col-md-12(ng-if="vm.platform === 'osx' && vm.archs.includes('arm64')")
+    .jumbotron
+      h4 OS X 
+        span.text-muted 64 bit ARM
+      a.btn.btn-success.btn-lg(
+        ng-click="vm.download(vm.latestReleases['arm64'])"
+        )
+        i.fa.fa-download.fa-5x
+        h5 {{ vm.latestReleases['arm64'].version }} 
+          label.label.label-info(
+            ng-show="vm.latestReleases['arm64'].channel !== 'stable'"
+            )
+            | {{ vm.latestReleases['arm64'].channel }}
+      .padding-top-20.text-muted
+        span.timestamp(am-time-ago="vm.latestReleases['arm64'].createdAt")
+      .padding-top-20(ng-show="vm.latestReleases['arm64'].notes")
+        h4 Change Notes
+        p.release-notes.text-muted(
+          ng-bind="vm.latestReleases['arm64'].notes"
           )
   div(ng-if="vm.platform !== 'osx'")
     .row


### PR DESCRIPTION
As apple has launched their new arm64 computer, we need to differentiate between intel and arm architectures.