### PR TITLE
Improve latest download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,7 @@
 
 config/local.js
 database.json
-
+releases
 
 
 

--- a/README.md
+++ b/README.md
@@ -26,13 +26,19 @@ If you host your project on your Github **and** do not need a UI for your app, t
 - :sparkles: Simple but powerful download urls (**NOTE:** when no assets are uploaded, server returns `404` by default):
     - `/download/latest`
     - `/download/latest/:platform`
+    - `/download/latest/:platform/:filename`
     - `/download/:version`
     - `/download/:version/:platform`
     - `/download/:version/:platform/:filename`
     - `/download/channel/:channel`
     - `/download/channel/:channel/:platform`
+    - `/download/channel/:channel/:platform/:filename`
     - `/download/flavor/:flavor/latest`
     - `/download/flavor/:flavor/latest/:platform`
+    - `/download/flavor/:flavor/latest/:platform/:filename`
+    - `/download/flavor/:flavor/latest/channel/:channel/`
+    - `/download/flavor/:flavor/latest/channel/:channel/:platform`
+    - `/download/flavor/:flavor/latest/channel/:channel/:platform/:filename`
     - `/download/flavor/:flavor/:version`
     - `/download/flavor/:flavor/:version/:platform`
     - `/download/flavor/:flavor/:version/:platform/:filename`

--- a/api/controllers/AssetController.js
+++ b/api/controllers/AssetController.js
@@ -9,6 +9,7 @@ var _ = require('lodash');
 var path = require('path');
 var actionUtil = require('sails/lib/hooks/blueprints/actionUtil');
 var Promise = require('bluebird');
+const PlatformService = require('../services/PlatformService');
 
 module.exports = {
 
@@ -19,12 +20,12 @@ module.exports = {
    * This is because Squirrel.Windows does a poor job of parsing the filename,
    * and so we must fake the filenames of x32 and x64 versions to be the same.
    *
-   * (GET /download/latest/:platform?': 'AssetController.download')
+   * (GET /download/latest/:platform?/:filename?': 'AssetController.download')
    * (GET /download/:version/:platform?/:filename?': 'AssetController.download')
-   * (GET /download/channel/:channel/:platform?': 'AssetController.download')
-   * (GET /download/flavor/:flavor/latest/:platform?': 'AssetController.download')
+   * (GET /download/channel/:channel/:platform?/:filename?': 'AssetController.download')
+   * (GET /download/flavor/:flavor/latest/:platform?/:filename?': 'AssetController.download')
    * (GET /download/flavor/:flavor/:version/:platform?/:filename?': 'AssetController.download')
-   * (GET /download/flavor/:flavor/channel/:channel/:platform?': 'AssetController.download')
+   * (GET /download/flavor/:flavor/channel/:channel/:platform?/:filename?': 'AssetController.download')
    */
   download: function(req, res) {
     var channel = req.params.channel;
@@ -37,7 +38,7 @@ module.exports = {
     var platforms;
     var platform = req.param('platform');
     if (platform) {
-      platforms = [platform];
+      platforms = PlatformService.detect(platform, true);
     }
 
     // Normalize filetype by prepending with period

--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -19,11 +19,15 @@ var AuthController = {
           return res.serverError('Could not retrieve user');
         }
 
+        const token = AuthToken.issueToken({
+          sub: user.username
+        })
+
+        res.cookie("authToken", token, {httpOnly: true, maxAge: 900000, secure: true})
+
         return res.json({
           user: user.username,
-          token: AuthToken.issueToken({
-            sub: user.username
-          })
+          token: token
         });
       });
   }

--- a/api/policies/authToken.js
+++ b/api/policies/authToken.js
@@ -25,6 +25,8 @@ module.exports = function(req, res, next) {
     token = req.param('token');
     // We delete the token from param to not mess with blueprints
     delete req.query.token;
+  }  else if (req.cookies && req.cookies.authToken) {
+    token = req.cookies.authToken;
   } else {
     return res.forbidden('No authorization header found.');
   }

--- a/config/policies.js
+++ b/config/policies.js
@@ -26,7 +26,11 @@ module.exports.policies = {
    *                                                                          *
    ***************************************************************************/
 
-  '*': true,
+  '*': 'authToken',
+
+  AuthController: {
+    login: 'noCache'
+  },
 
   AssetController: {
     create: 'authToken',
@@ -55,6 +59,8 @@ module.exports.policies = {
     redirect: 'noCache',
     general: 'noCache',
     windows: 'noCache',
-    releaseNotes: 'noCache'
+    releaseNotes: 'noCache',
+    electronUpdaterWin: 'noCache',
+    electronUpdaterMac: 'noCache'
   }
 };

--- a/config/routes.js
+++ b/config/routes.js
@@ -31,11 +31,11 @@ module.exports.routes = {
 
   'PUT /version/availability/:version/:timestamp': 'VersionController.availability',
 
-  'GET /download/latest/:platform?': 'AssetController.download',
-  'GET /download/channel/:channel/:platform?': 'AssetController.download',
+  'GET /download/latest/:platform?/:filename?': 'AssetController.download',
+  'GET /download/channel/:channel/:platform?/:filename?': 'AssetController.download',
   'GET /download/:version/:platform?/:filename?': 'AssetController.download',
-  'GET /download/flavor/:flavor/latest/:platform?': 'AssetController.download',
-  'GET /download/flavor/:flavor/channel/:channel/:platform?': 'AssetController.download',
+  'GET /download/flavor/:flavor/latest/:platform?/:filename?': 'AssetController.download',
+  'GET /download/flavor/:flavor/channel/:channel/:platform?/:filename?': 'AssetController.download',
   'GET /download/flavor/:flavor/:version/:platform?/:filename?': 'AssetController.download',
 
   'GET /update': 'VersionController.redirect',

--- a/config/routes.js
+++ b/config/routes.js
@@ -36,6 +36,7 @@ module.exports.routes = {
   'GET /download/:version/:platform?/:filename?': 'AssetController.download',
   'GET /download/flavor/:flavor/latest/:platform?/:filename?': 'AssetController.download',
   'GET /download/flavor/:flavor/channel/:channel/:platform?/:filename?': 'AssetController.download',
+  'GET /download/flavor/:flavor/latest/channel/:channel/:platform?/:filename?': 'AssetController.download',
   'GET /download/flavor/:flavor/:version/:platform?/:filename?': 'AssetController.download',
 
   'GET /update': 'VersionController.redirect',

--- a/docs/urls.md
+++ b/docs/urls.md
@@ -8,6 +8,10 @@ Electron Release Server provides a variety of urls to access release assets.
 #### Latest version for specific platform:
 - `http://download.myapp.com/download/latest/osx`
 - `http://download.myapp.com/download/flavor/default/latest/osx`
+#### Latest version for specific platform and file extension
+- `http://download.myapp.com/download/latest/osx/update.zip`
+- `http://download.myapp.com/download/flavor/default/latest/osx/update.dmg`
+- `http://download.myapp.com/download/flavor/default/latest/channel/stable/osx/update.dmg`
 #### Specific version for detected platform:
 - `http://download.myapp.com/download/1.1.0`
 - `http://download.myapp.com/download/flavor/default/1.1.0`


### PR DESCRIPTION
What is changed:
- The platform in the URL is now detected by `PlatformService.detect` so you don't have to specify a perfect match anymore
- The latest download now support arbitrary filenames/extensions and channels so you are not limited to a default file extension or channel
- The `releases/` directory is added to `.gitignore`

The documentation is updated accordingly.