### PR TITLE
Fixing bug with bootstrap-sass.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "angular": "1.5.9",
-    "bootstrap-sass-official": "^3.3.7",
+    "bootstrap-sass-official": "~3.3.7",
     "angular-animate": "1.5.9",
     "angular-messages": "~1.5.9",
     "angular-route": "~1.5.9",


### PR DESCRIPTION
Newer versions of bootstrap-sass-official are not compatible with the version of sass used in this project as it includes changes to the way division works. 

This issue is documented in these issues; https://github.com/twbs/bootstrap-sass/issues/1231 and https://github.com/twbs/bootstrap-sass/issues/1230. 

Making the version of bootstrap-sass required more specific stops the breaking upgrade.