### PR TITLE
add delta flag to asset id if needed

### DIFF
--- a/api/models/Asset.js
+++ b/api/models/Asset.js
@@ -60,9 +60,10 @@ module.exports = {
   autoPK: false,
 
   beforeCreate: (asset, proceed) => {
-    const { version, platform, filetype } = asset;
+    const { name, version, platform, filetype } = asset;
 
-    asset.id = `${version}_${platform}_${filetype.replace(/\./g, '')}`;
+    const delta = name && name.toLowerCase().includes('-delta') ? 'delta_' : '';
+    asset.id = `${version}_${platform}_${delta}${filetype.replace(/\./g, '')}`;
 
     return proceed();
   }


### PR DESCRIPTION
This PR fixes an error I was seeing while publishing a release using electron-forge/publisher-eletron-release-server. 

The assets being uploaded included both a full and delta nupkg and electron-release-server returned a HTTP error 400 with the error explanation that the asset id already exists.

The fix is to include _delta_ in the generated asset ID so that it is a unique primary key.

