### PR TITLE
Fix/invalid version semver error

### DIFF
--- a/api/controllers/VersionController.js
+++ b/api/controllers/VersionController.js
@@ -399,8 +399,8 @@ module.exports = {
                     function(asset) {
                       return asset.filetype === '.nupkg'
                         && _.includes(asset.name.toLowerCase(), '-delta')
-                        && semver.lte(version, asset.version)
-                        && semver.gt(latestVersion.name, asset.version);
+                        && semver.lte(version, newVersion.name)
+                        && semver.gt(latestVersion.name, newVersion.name);
                     }));
               }, []);
 

--- a/api/controllers/VersionController.js
+++ b/api/controllers/VersionController.js
@@ -406,10 +406,6 @@ module.exports = {
 
             Array.prototype.unshift.apply(latestVersion.assets, deltaAssets);
 
-            latestVersion.assets.sort(function(a1, a2) {
-              return semver.compare(a1.version, a2.version);
-            });
-
             sails.log.debug('Latest Windows Version', latestVersion);
 
             // Change asset name to use full download link


### PR DESCRIPTION
Came across an error where a string used for semver test was invalid (it was trying to compare with the `${name}_${flavor}` version id ).

Changed to use the parent side of the model relationship.