### PR TITLE
Fix the remaining Sails V1 upgrade issues

### DIFF
--- a/api/controllers/AssetController.js
+++ b/api/controllers/AssetController.js
@@ -234,7 +234,12 @@ module.exports = {
                   fd: uploadedFile.fd,
                   size: uploadedFile.size
                 }, data);
+
+                // Due to an API change in Sails/Waterline, the primary key values must be specified directly.=
                 newAsset.version = newAsset.version.id;
+
+                const delta = newAsset.name && newAsset.name.toLowerCase().includes('-delta') ? 'delta_' : '';
+                newAsset.id = `${newAsset.version}_${newAsset.platform}_${delta}${newAsset.filetype.replace(/\./g, '')}`;
 
                 // Create new instance of model using data from params
                 Asset

--- a/api/models/Asset.js
+++ b/api/models/Asset.js
@@ -1,7 +1,7 @@
 /**
  * Asset.js
  *
- * @description :: TODO: You might write a short summary of how this model works and what it represents here.
+ * @description :: A software asset that can be used to install the app (ex. .exe, .dmg, .deb, etc.)
  * @docs        :: http://sailsjs.org/#!documentation/models
  */
 
@@ -13,7 +13,8 @@ module.exports = {
 
     id: {
       type: 'string',
-      unique: true
+      unique: true,
+      required: true
     },
 
     name: {
@@ -56,15 +57,6 @@ module.exports = {
       type: 'string',
       required: true
     }
-  },
-
-  beforeCreate: (asset, proceed) => {
-    const { name, version, platform, filetype } = asset;
-
-    const delta = name && name.toLowerCase().includes('-delta') ? 'delta_' : '';
-    asset.id = `${version}_${platform}_${delta}${filetype.replace(/\./g, '')}`;
-
-    return proceed();
   }
 
 };

--- a/api/models/Version.js
+++ b/api/models/Version.js
@@ -12,7 +12,8 @@ module.exports = {
   attributes: {
     id: {
       type: 'string',
-      unique: true
+      unique: true,
+      required: true
     },
 
     name: {
@@ -31,8 +32,7 @@ module.exports = {
     },
 
     availability: {
-      type: 'string',
-      columnType: 'datetime'
+      type: 'string'
     },
 
     flavor: {

--- a/assets/js/admin/add-version-modal/add-version-modal-controller.js
+++ b/assets/js/admin/add-version-modal/add-version-modal-controller.js
@@ -6,6 +6,7 @@ angular.module('app.admin.add-version-modal', [])
       $scope.availableFlavors = DataService.availableFlavors;
 
       $scope.version = {
+        id: '',
         name: '',
         notes: '',
         channel: {
@@ -34,6 +35,7 @@ angular.module('app.admin.add-version-modal', [])
         $scope.availableFlavors = DataService.availableFlavors;
 
         $scope.version = {
+          id: '',
           name: '',
           notes: '',
           channel: {

--- a/assets/js/core/data/data-service.js
+++ b/assets/js/core/data/data-service.js
@@ -138,6 +138,7 @@ angular.module('app.core.data.service', [
         var version_for_request = version;
         version_for_request.channel = version_for_request.channel.name;
         version_for_request.flavor = version_for_request.flavor.name;
+        version_for_request.id = `${version_for_request.name}_${version_for_request.flavor}`;
 
         return $http.post('/api/version', version_for_request)
           .then(function(response) {

--- a/config/docker.js
+++ b/config/docker.js
@@ -49,7 +49,7 @@ module.exports = {
   session: {
     // Recommended: 63 random alpha-numeric characters
     // Generate using: https://www.grc.com/passwords.htm
-    token_secret: process.env['TOKEN_SECRET'],
+    secret: process.env['TOKEN_SECRET'],
     database: process.env['DB_NAME'] || process.env['DATABASE_URL'] && process.env['DATABASE_URL'].split('/')[3],
     host: process.env['DB_HOST'] || process.env['DATABASE_URL'] && process.env['DATABASE_URL'].split('@')[1].split(':')[0],
     user: process.env['DB_USERNAME'] || process.env['DATABASE_URL'] && process.env['DATABASE_URL'].split('@')[0].split(':')[1].split('/')[2],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,12 +22,12 @@ services:
       # Recommended: 63 random alpha-numeric characters
       # Generate using: https://www.grc.com/passwords.htm
       TOKEN_SECRET: change_me_in_production
-      APP_URL: 'localhost:5000'
+      APP_URL: 'localhost:8080'
       ASSETS_PATH: '/usr/src/electron-release-server/releases'
     depends_on:
       - db
     ports:
-      - '5000:80'
+      - '8080:80'
     entrypoint: ./scripts/wait.sh db:5432 -- npm start
     volumes:
       - ./releases:/usr/src/electron-release-server/releases

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -10,8 +10,8 @@ Install [docker](https://www.docker.com/) and [docker-compose](https://github.co
 ## Localserver
 
 ```bash
-docker-compose up -d
-# open localhost:5000 in browser
+docker-compose up
+# open localhost:8080 in browser
 ```
 
 If you use [docker-machine](https://github.com/docker/machine) you should change

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-release-server",
   "private": true,
-  "version": "1.5.2",
+  "version": "2.1.2",
   "description": "A version server for hosting and serving the your electron desktop app releases.",
   "dependencies": {
     "@sailshq/upgrade": "^1.0.9",


### PR DESCRIPTION
- Make the primary key fields for Asset and Version required and move their initialiation
- Correct the column type for Version.availability
- Fix session.token_secret to session.secret in docker.js
- Use port 8080 instead of 5000 for the default docker config since macOS now uses 5000 for AirPlay
- Bump the package.json version to v2.1.2