### PR TITLE
Specify number column types (Fixes #316)

### DIFF
--- a/api/models/Asset.js
+++ b/api/models/Asset.js
@@ -39,12 +39,14 @@ module.exports = {
 
     size: {
       type: 'number',
-      required: true
+      required: true,
+      columnType: 'integer'
     },
 
     download_count: {
       type: 'number',
-      defaultsTo: 0
+      defaultsTo: 0,
+      columnType: 'integer'
     },
 
     version: {


### PR DESCRIPTION
WaterlineJS defaults to using floating point field types for number fields. The causes precision issues for file sizes since the reported file sizes do not match the assets. This would also prevent the download count tracking to work once the count is high enough such that one download is beyond the supported precision.

Note: users must update their existing database schemas to avoid these issues.