### PR TITLE
Disallow uploading RELEASES files (fixes #313)

### DIFF
--- a/api/controllers/AssetController.js
+++ b/api/controllers/AssetController.js
@@ -96,7 +96,6 @@ module.exports = {
               // an lower version could be deleted then be created again,
               // thus it has newer `createdAt`.
               versions = versions.sort(UtilityService.compareVersion);
-              var version = versions[0];
               var version;
               for (var i = 0; i < versions.length; i++) {
                 version = versions[i];
@@ -204,6 +203,11 @@ module.exports = {
             }
 
             var uploadedFile = uploadedFiles[0];
+
+            if (uploadedFile.filename === 'RELEASES') {
+              return res.badRequest(
+                'The RELEASES file should not be uploaded since the release server will generate at request time');
+            }
 
             var fileExt = path.extname(uploadedFile.filename);
 


### PR DESCRIPTION
Although the front end won't allow a user to upload a `RELEASES` file, some users may try to do so through the API.
Since the server generates these files, we don't wish for such files to be redundantly uploaded.
In fact, trying to upload such files would previously result in a 500 (server error) response code. With this change, the user will receive a 400 (bad request) response with a more intuitive error message.