### PR TITLE
Update `setFeedURL` call in OS X docs

### DIFF
--- a/docs/update-osx.md
+++ b/docs/update-osx.md
@@ -28,6 +28,7 @@ var autoUpdater = require('electron').autoUpdater;
 
 var platform = os.platform() + '_' + os.arch();  // usually returns darwin_64
 var version = app.getVersion();
+var channel = 'stable';
 
-autoUpdater.setFeedURL('http://download.myapp.com/update/'+platform+'/'+version);
+autoUpdater.setFeedURL('http://download.myapp.com/update/' + platform + '/' + version + '/' + channel);
 ```


### PR DESCRIPTION
Could not get it working without an explicit channel in the feed url.

Without the channel, I got 404 and and error event with this message: `Update check failed. The server sent an invalid response. Try again later.`.

Maybe this is a bug and the docs are not to blame (since channel parameter is said to be optional in README), but full feed url with explicit channel is still valid, so this patch does no harm I guess.