### PR TITLE
Improve latest download (2.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,7 @@
 
 config/local.js
 database.json
-
+releases
 
 
 

--- a/README.md
+++ b/README.md
@@ -26,13 +26,19 @@ If you host your project on your Github **and** do not need a UI for your app, t
 - :sparkles: Simple but powerful download urls (**NOTE:** when no assets are uploaded, server returns `404` by default):
     - `/download/latest`
     - `/download/latest/:platform`
+    - `/download/latest/:platform/:filename`
     - `/download/:version`
     - `/download/:version/:platform`
     - `/download/:version/:platform/:filename`
     - `/download/channel/:channel`
     - `/download/channel/:channel/:platform`
+    - `/download/channel/:channel/:platform/:filename`
     - `/download/flavor/:flavor/latest`
     - `/download/flavor/:flavor/latest/:platform`
+    - `/download/flavor/:flavor/latest/:platform/:filename`
+    - `/download/flavor/:flavor/latest/channel/:channel/`
+    - `/download/flavor/:flavor/latest/channel/:channel/:platform`
+    - `/download/flavor/:flavor/latest/channel/:channel/:platform/:filename`
     - `/download/flavor/:flavor/:version`
     - `/download/flavor/:flavor/:version/:platform`
     - `/download/flavor/:flavor/:version/:platform/:filename`

--- a/api/controllers/AssetController.js
+++ b/api/controllers/AssetController.js
@@ -9,6 +9,7 @@ var _ = require('lodash');
 var path = require('path');
 var actionUtil = require('sails/lib/hooks/blueprints/actionUtil');
 var Promise = require('bluebird');
+const PlatformService = require('../services/PlatformService');
 
 module.exports = {
 
@@ -19,12 +20,12 @@ module.exports = {
    * This is because Squirrel.Windows does a poor job of parsing the filename,
    * and so we must fake the filenames of x32 and x64 versions to be the same.
    *
-   * (GET /download/latest/:platform?': 'AssetController.download')
+   * (GET /download/latest/:platform?/:filename?': 'AssetController.download')
    * (GET /download/:version/:platform?/:filename?': 'AssetController.download')
-   * (GET /download/channel/:channel/:platform?': 'AssetController.download')
-   * (GET /download/flavor/:flavor/latest/:platform?': 'AssetController.download')
+   * (GET /download/channel/:channel/:platform?/:filename?': 'AssetController.download')
+   * (GET /download/flavor/:flavor/latest/:platform?/:filename?': 'AssetController.download')
    * (GET /download/flavor/:flavor/:version/:platform?/:filename?': 'AssetController.download')
-   * (GET /download/flavor/:flavor/channel/:channel/:platform?': 'AssetController.download')
+   * (GET /download/flavor/:flavor/channel/:channel/:platform?/:filename?': 'AssetController.download')
    */
   download: function(req, res) {
     var channel = req.params.channel;
@@ -37,7 +38,7 @@ module.exports = {
     var platforms;
     var platform = req.param('platform');
     if (platform) {
-      platforms = [platform];
+      platforms = PlatformService.detect(platform, true);
     }
 
     // Normalize filetype by prepending with period

--- a/config/routes.js
+++ b/config/routes.js
@@ -41,13 +41,13 @@ module.exports.routes = {
   },
   'GET /download/flavor/:flavor/latest/:platform?/:filename?': 'AssetController.download',
   'GET /download/flavor/:flavor/channel/:channel/:platform?/:filename?': 'AssetController.download',
+  'GET /download/flavor/:flavor/latest/channel/:channel/:platform?/:filename?': 'AssetController.download',
   'GET /download/flavor/:flavor/:version/:platform?/:filename?': {
     controller: 'AssetController',
     action: 'download',
     // This is important since it allows matching with filenames.
     skipAssets: false
   },
-
   'GET /update': 'VersionController.redirect',
   'GET /update/:platform/latest-mac.yml': 'VersionController.electronUpdaterMac',
   'GET /update/:platform/:channel-mac.yml': 'VersionController.electronUpdaterMac',

--- a/config/routes.js
+++ b/config/routes.js
@@ -31,16 +31,16 @@ module.exports.routes = {
 
   'PUT /version/availability/:version/:timestamp': 'VersionController.availability',
 
-  'GET /download/latest/:platform?': 'AssetController.download',
-  'GET /download/channel/:channel/:platform?': 'AssetController.download',
+  'GET /download/latest/:platform?/:filename?': 'AssetController.download',
+  'GET /download/channel/:channel/:platform?/:filename?': 'AssetController.download',
   'GET /download/:version/:platform?/:filename?': {
     controller: 'AssetController',
     action: 'download',
     // This is important since it allows matching with filenames.
     skipAssets: false
   },
-  'GET /download/flavor/:flavor/latest/:platform?': 'AssetController.download',
-  'GET /download/flavor/:flavor/channel/:channel/:platform?': 'AssetController.download',
+  'GET /download/flavor/:flavor/latest/:platform?/:filename?': 'AssetController.download',
+  'GET /download/flavor/:flavor/channel/:channel/:platform?/:filename?': 'AssetController.download',
   'GET /download/flavor/:flavor/:version/:platform?/:filename?': {
     controller: 'AssetController',
     action: 'download',

--- a/config/routes.js
+++ b/config/routes.js
@@ -30,18 +30,42 @@ module.exports.routes = {
   '/auth/logout': { view: 'homepage' },
 
   'PUT /version/availability/:version/:timestamp': 'VersionController.availability',
-
-  'GET /download/latest/:platform?/:filename?': 'AssetController.download',
-  'GET /download/channel/:channel/:platform?/:filename?': 'AssetController.download',
+  'GET /download/latest/:platform?/:filename?': {
+    controller: 'AssetController',
+    action: 'download',
+    // This is important since it allows matching with filenames.
+    skipAssets: false
+  },
+  'GET /download/channel/:channel/:platform?/:filename?': {
+    controller: 'AssetController',
+    action: 'download',
+    // This is important since it allows matching with filenames.
+    skipAssets: false
+  },
   'GET /download/:version/:platform?/:filename?': {
     controller: 'AssetController',
     action: 'download',
     // This is important since it allows matching with filenames.
     skipAssets: false
   },
-  'GET /download/flavor/:flavor/latest/:platform?/:filename?': 'AssetController.download',
-  'GET /download/flavor/:flavor/channel/:channel/:platform?/:filename?': 'AssetController.download',
-  'GET /download/flavor/:flavor/latest/channel/:channel/:platform?/:filename?': 'AssetController.download',
+  'GET /download/flavor/:flavor/latest/:platform?/:filename?': {
+    controller: 'AssetController',
+    action: 'download',
+    // This is important since it allows matching with filenames.
+    skipAssets: false
+  },
+  'GET /download/flavor/:flavor/channel/:channel/:platform?/:filename?': {
+    controller: 'AssetController',
+    action: 'download',
+    // This is important since it allows matching with filenames.
+    skipAssets: false
+  },
+  'GET /download/flavor/:flavor/latest/channel/:channel/:platform?/:filename?': {
+    controller: 'AssetController',
+    action: 'download',
+    // This is important since it allows matching with filenames.
+    skipAssets: false
+  },
   'GET /download/flavor/:flavor/:version/:platform?/:filename?': {
     controller: 'AssetController',
     action: 'download',

--- a/docs/urls.md
+++ b/docs/urls.md
@@ -8,6 +8,10 @@ Electron Release Server provides a variety of urls to access release assets.
 #### Latest version for specific platform:
 - `http://download.myapp.com/download/latest/osx`
 - `http://download.myapp.com/download/flavor/default/latest/osx`
+#### Latest version for specific platform and file extension
+- `http://download.myapp.com/download/latest/osx/update.zip`
+- `http://download.myapp.com/download/flavor/default/latest/osx/update.dmg`
+- `http://download.myapp.com/download/flavor/default/latest/channel/stable/osx/update.dmg`
 #### Specific version for detected platform:
 - `http://download.myapp.com/download/1.1.0`
 - `http://download.myapp.com/download/flavor/default/1.1.0`


### PR DESCRIPTION
This is a repeat of PR https://github.com/ArekSredzki/electron-release-server/pull/288 which has been synchronized with the current master branch. The previous PR was reverted since another commit was pushed which was not meant to be merged.

What is changed:
- The platform in the URL is now detected by `PlatformService.detect` so you don't have to specify a perfect match anymore
- The latest download now support arbitrary filenames/extensions and channels so you are not limited to a default file extension or channel
- The `releases/` directory is added to `.gitignore`

The documentation is updated accordingly.