### PR TITLE
Remove the arm64 option from being offered

### DIFF
--- a/assets/js/download/download-controller.js
+++ b/assets/js/download/download-controller.js
@@ -19,7 +19,7 @@ angular.module('app.releases', [])
       self.platform = deviceDetector.os;
       if (self.platform === 'mac') {
         self.platform = 'osx';
-        self.archs = ['64', 'arm64'];
+        self.archs = ['64']; // ['64', 'arm64']; // Don't show the arm64 option
       } else {
         self.archs = ['32', '64'];
       }


### PR DESCRIPTION
This is a hardcoded hack because of a bug that offers an arm64 download option even though it doesn't exist