### PR TITLE
fix macos download page

### DIFF
--- a/assets/js/download/download.pug
+++ b/assets/js/download/download.pug
@@ -16,7 +16,7 @@
           ng-change='vm.getLatestReleases()'
           )
 .row.text-center.padding-top-20(ng-if="vm.latestReleases")
-  .col-md-12(ng-if="vm.platform === 'osx' && !vm.archs.includes('arm64')")
+  .col-md-12(ng-if="vm.platform === 'osx' && vm.latestReleases['64']")
     .jumbotron
       h4 OS X 
         span.text-muted 64 bit INTEL
@@ -36,7 +36,7 @@
         p.release-notes.text-muted(
           ng-bind="vm.latestReleases['64'].notes"
           )
-  .col-md-12(ng-if="vm.platform === 'osx' && vm.archs.includes('arm64')")
+  .col-md-12(ng-if="vm.platform === 'osx' && vm.latestReleases['arm64']")
     .jumbotron
       h4 OS X 
         span.text-muted 64 bit ARM


### PR DESCRIPTION
Hello!
When you show download variants for MacOs, You checking for vm.archs.includes('arm64'). But 'arm64' always persist in that array. So MacOs always try to download 'arm64' architecture. These fix made download button working correctly in MacOS