### PR TITLE
Changed the initial APP_URL in the docker-compose.yml file so that development works out of the box

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       # Recommended: 63 random alpha-numeric characters
       # Generate using: https://www.grc.com/passwords.htm
       TOKEN_SECRET: change_me_in_production
-      APP_URL: 'localhost:8080'
+      APP_URL: 'http://localhost:8080'
       ASSETS_PATH: '/usr/src/electron-release-server/releases'
     depends_on:
       - db


### PR DESCRIPTION
The fix is connected to [this comment](https://github.com/ArekSredzki/electron-release-server/issues/278#issuecomment-1816657431).

I was thinking about putting in a URL check where `sails.config.appUrl` is used, but that would just complicate everything in my opinion. For now, I think it's best if we simply fix the initial issue.

With this change, the MacOS and Windows auto-update feature of the dockerized app will work out of the box.