### PR TITLE
Fix edit version modal in admin panel

### DIFF
--- a/assets/js/core/data/data-service.js
+++ b/assets/js/core/data/data-service.js
@@ -211,7 +211,7 @@ angular.module('app.core.data.service', [
         version_for_request.channel = version_for_request.channel.name;
         version_for_request.flavor = version_for_request.flavor.name;
 
-        return $http.post(
+        return $http.patch(
             '/api/version/' + version.id,
             version_for_request
           )


### PR DESCRIPTION
The edit version modal in the admin panel is buggy. It will send a `POST` request to update an existing `Version` but that will fail. It should send a `PATCH` request.

>For example, with [rest](https://sailsjs.com/documentation/reference/configuration/sails-config-blueprints#?routerelated-settings) enabled, having a Boat model in your app generates the following routes:
>
>   GET /boat -> find boats matching criteria provided on the query string, using the [find blueprint](https://sailsjs.com/documentation/reference/blueprint-api/find-where).
    GET /boat/:id -> find a single boat with the given unique ID (i.e. primary key) value, using the [findOne blueprint](https://sailsjs.com/documentation/reference/blueprint-api/find-one).
    POST /boat -> create a new boat with the attributes provided in the request body, using the [create blueprint](https://sailsjs.com/documentation/reference/blueprint-api/create).
    PATCH /boat/:id -> update the boat with the given unique ID with the attributes provided in the request body, using the [update blueprint](https://sailsjs.com/documentation/reference/blueprint-api/update).
    DELETE /boat/:id -> destroy the boat with the given unique ID, using the [destroy blueprint](https://sailsjs.com/documentation/reference/blueprint-api/destroy).

Source https://sailsjs.com/documentation/concepts/blueprints/blueprint-routes