### PR TITLE
Add more accepted file extensions to file input

### DIFF
--- a/assets/js/admin/add-version-asset-modal/add-version-asset-modal.pug
+++ b/assets/js/admin/add-version-asset-modal/add-version-asset-modal.pug
@@ -32,7 +32,7 @@ form(name='assetForm', role='form')
             ngf-change='updateAssetName()',
             ng-model='asset.file',
             name='file',
-            ngf-accept="'.dmg,.zip,.deb,.exe,.nupkg,.blockmap'",
+            ngf-accept="'.dmg,.pkg,.mas,.zip,.deb,.rpm,.AppImage,.exe,.nupkg,.msi,.blockmap'",
             ngf-max-size='500MB',
             required='',
             )


### PR DESCRIPTION
It's annoying that when uploading files some file types do not show up initially and you have to change the file type filter in the system file picker dialog each time to select `.AppImage` for example.

I took all file extensions from here:

https://github.com/ArekSredzki/electron-release-server/blob/042567b37419ed2d74c740128b8f870baa5e86bc/assets/js/core/data/data-service.js#L36-L41